### PR TITLE
Fix/widget props

### DIFF
--- a/apps/www/src/invitations/dashboard/components/EditTemplate.tsx
+++ b/apps/www/src/invitations/dashboard/components/EditTemplate.tsx
@@ -32,7 +32,7 @@ function EditTemplate() {
           <div className="space-y-6">
             {/** 아래 그냥 예시입니다 */}
             {invitation?.widgets[1] ? (
-              <Widget widgetType={invitation.widgets[1].type} invitation={invitation} />
+              <Widget invitation={invitation} widgetItem={invitation.widgets[1]} />
             ) : null}
           </div>
         </div>

--- a/apps/www/src/invitations/dashboard/components/EditTemplate.tsx
+++ b/apps/www/src/invitations/dashboard/components/EditTemplate.tsx
@@ -32,7 +32,7 @@ function EditTemplate() {
           <div className="space-y-6">
             {/** 아래 그냥 예시입니다 */}
             {invitation?.widgets[1] ? (
-              <Widget widgetType={invitation.widgets[1].type} widgetItem={invitation.widgets[1]} />
+              <Widget widgetType={invitation.widgets[1].type} invitation={invitation} />
             ) : null}
           </div>
         </div>

--- a/apps/www/src/widget/common/Widget.tsx
+++ b/apps/www/src/widget/common/Widget.tsx
@@ -1,23 +1,26 @@
 import dynamic from 'next/dynamic';
 import { memo } from 'react';
 
-import type { IInvitation, WidgetType } from '@/types/pageBrothers.type';
+import type { IInvitation, WidgetItem } from '@/types/pageBrothers.type';
 
 interface WidgetProps {
-  widgetType: WidgetType;
   invitation: IInvitation;
+  widgetItem: WidgetItem;
 }
 
-const components: Record<string, React.ComponentType<{ invitation: IInvitation }>> = {
+const components: Record<
+  string,
+  React.ComponentType<{ invitation?: IInvitation; widgetItem: WidgetItem }>
+> = {
   VIDEO: dynamic(() => import('../video/VideoWidget'), {
     ssr: false,
   }),
 };
 
-function Widget({ widgetType, invitation }: WidgetProps) {
-  const Component = components[widgetType];
+function Widget({ invitation, widgetItem }: WidgetProps) {
+  const Component = components[widgetItem.type];
 
-  return <Component invitation={invitation} />;
+  return <Component invitation={invitation} widgetItem={widgetItem} />;
 }
 
 export default memo(Widget);

--- a/apps/www/src/widget/common/Widget.tsx
+++ b/apps/www/src/widget/common/Widget.tsx
@@ -1,23 +1,23 @@
 import dynamic from 'next/dynamic';
 import { memo } from 'react';
 
-import type { WidgetItem, WidgetType } from '@/types/pageBrothers.type';
+import type { IInvitation, WidgetType } from '@/types/pageBrothers.type';
 
 interface WidgetProps {
   widgetType: WidgetType;
-  widgetItem: WidgetItem;
+  invitation: IInvitation;
 }
 
-const components: Record<string, React.ComponentType<WidgetItem>> = {
+const components: Record<string, React.ComponentType<{ invitation: IInvitation }>> = {
   VIDEO: dynamic(() => import('../video/VideoWidget'), {
     ssr: false,
   }),
 };
 
-function Widget({ widgetType, widgetItem }: WidgetProps) {
+function Widget({ widgetType, invitation }: WidgetProps) {
   const Component = components[widgetType];
 
-  return <Component {...widgetItem} />;
+  return <Component invitation={invitation} />;
 }
 
 export default memo(Widget);

--- a/apps/www/src/widget/video/VideoWidget.tsx
+++ b/apps/www/src/widget/video/VideoWidget.tsx
@@ -1,18 +1,13 @@
-import { useMemo } from 'react';
-
-import type { IInvitation } from '@/types/pageBrothers.type';
+import type { IInvitation, VideoWidgetConfig, WidgetItem } from '@/types/pageBrothers.type';
 import { WidgetWrapper } from '@/widget/common';
 
 interface VideoWidgetProps {
-  invitation: IInvitation;
+  invitation?: IInvitation;
+  widgetItem: WidgetItem;
 }
 
-function VideoWidget({ invitation }: VideoWidgetProps): React.ReactNode {
-  const url = useMemo(() => {
-    return invitation.widgets
-      .find((widget) => widget.type === 'VIDEO')
-      ?.config.url.replace('watch?v=', 'embed/');
-  }, [invitation]);
+function VideoWidget({ widgetItem }: VideoWidgetProps): React.ReactNode {
+  const url = (widgetItem.config as VideoWidgetConfig).url.replace('watch?v=', 'embed/');
 
   return (
     <WidgetWrapper title="동영상">

--- a/apps/www/src/widget/video/VideoWidget.tsx
+++ b/apps/www/src/widget/video/VideoWidget.tsx
@@ -1,8 +1,18 @@
-import type { VideoWidgetConfig, WidgetItem } from '@/types/pageBrothers.type';
+import { useMemo } from 'react';
+
+import type { IInvitation } from '@/types/pageBrothers.type';
 import { WidgetWrapper } from '@/widget/common';
 
-function VideoWidget(widgetItem: WidgetItem): React.ReactNode {
-  const url = (widgetItem.config as VideoWidgetConfig).url.replace('watch?v=', 'embed/');
+interface VideoWidgetProps {
+  invitation: IInvitation;
+}
+
+function VideoWidget({ invitation }: VideoWidgetProps): React.ReactNode {
+  const url = useMemo(() => {
+    return invitation.widgets
+      .find((widget) => widget.type === 'VIDEO')
+      ?.config.url.replace('watch?v=', 'embed/');
+  }, [invitation]);
 
   return (
     <WidgetWrapper title="동영상">


### PR DESCRIPTION
**📌 pnpm build 실행시 빌드 에러가 없었나요?>>넵<<**

## 작업 내용 🗒︎

- Widget.tsx 에서 widgetItem : WidgetItem 에 더해 invitation : IInvitation 을 props 로 받도록 수정
- 각 위젯컴포넌트에서 props를 구조분해할당하여 받을 수 있도록 수정

## 기술적 의사 결정 🔍︎

- intro 위젯을 분석하던 중, eventAt 과 location 정보도 위젯 UI에 필요하다는 것을 확인하고 widgetItem에 더해 invitation 도 받을 수 있도록 수정했습니다.
- 처음에는 invitation 안에 widgets 가 있으므로, invitation 만 받을까 생각했었는데, 비디오 등의 여러번 들어갈 수 있는 위젯의 경우는 대처가 복잡해질 것 같아서 그냥 둘다 받는 것으로 하였습니다.
